### PR TITLE
refactor(style): make button spacing more proportional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 
-## [1.3.7+2] - 16 October 2023
+## [1.3.8] - 16 October 2023
 
 Ref: fix button spacing issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## [1.3.7+2] - 16 October 2023
+
+Ref: fix button spacing issue
+
 ## [1.3.7+1] - 9 July 2023
 
 Feat: Add CI/CD workflow

--- a/lib/buttons_tabbar.dart
+++ b/lib/buttons_tabbar.dart
@@ -326,12 +326,7 @@ class _ButtonsTabBarState extends State<ButtonsTabBar>
         ),
         animationValue);
 
-    var margin = EdgeInsets.only(
-      top: widget.buttonMargin.top,
-      bottom: widget.buttonMargin.bottom,
-      left: widget.buttonMargin.left / 2,
-      right: widget.buttonMargin.right / 2,
-    );
+    EdgeInsets margin;
 
     if (index == 0) {
       margin = EdgeInsets.only(
@@ -346,6 +341,13 @@ class _ButtonsTabBarState extends State<ButtonsTabBar>
         bottom: widget.buttonMargin.bottom,
         right: widget.buttonMargin.right,
         left: widget.buttonMargin.left / 2,
+      );
+    } else {
+      margin = EdgeInsets.only(
+        top: widget.buttonMargin.top,
+        bottom: widget.buttonMargin.bottom,
+        left: widget.buttonMargin.left / 2,
+        right: widget.buttonMargin.right / 2,
       );
     }
 

--- a/lib/buttons_tabbar.dart
+++ b/lib/buttons_tabbar.dart
@@ -326,16 +326,34 @@ class _ButtonsTabBarState extends State<ButtonsTabBar>
         ),
         animationValue);
 
+    var margin = EdgeInsets.only(
+      top: widget.buttonMargin.top,
+      bottom: widget.buttonMargin.bottom,
+      left: widget.buttonMargin.left / 2,
+      right: widget.buttonMargin.right / 2,
+    );
+
     if (index == 0) {
-      //
+      margin = EdgeInsets.only(
+        top: widget.buttonMargin.top,
+        bottom: widget.buttonMargin.bottom,
+        left: widget.buttonMargin.left,
+        right: widget.buttonMargin.right / 2,
+      );
     } else if (index == widget.tabs.length - 1) {
-      //
+      margin = EdgeInsets.only(
+        top: widget.buttonMargin.top,
+        bottom: widget.buttonMargin.bottom,
+        right: widget.buttonMargin.right,
+        left: widget.buttonMargin.left / 2,
+      );
     }
+
 
     return Padding(
       key: _tabKeys[index],
       // padding for the buttons
-      padding: widget.buttonMargin,
+      padding: margin,
       child: TextButton(
         onPressed: () {
           _controller?.animateTo(index);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.7+1
+version: 1.3.8+1
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.7+2
+version: 1.3.8
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.8+1
+version: 1.3.7+2
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 


### PR DESCRIPTION
**Pull Request Description**

In this pull request, I've undertaken a significant style enhancement focused on creating a more visually harmonious user interface. The issue at hand was the irregular spacing between buttons caused by direct padding implementation. Previously, when padding was directly applied using `EdgeInsets.all(16)`, it resulted in uneven distances between buttons, leading to an unbalanced layout:

**Before:**
```
16 -- First Tab -- 16 -- 16 -- Second Tab -- 16 -- 16 -- Last Tab -- 16
```
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-10-14 at 11 33 20](https://github.com/afonsocraposo/buttons_tabbar/assets/43450710/7680bf6d-fa9a-431e-a031-9bc7e8cedfb7)



To rectify this, I've implemented a more precise logic to ensure proportional spacing between buttons. Through careful adjustments in the code, I've calculated margins dynamically based on the provided `widget.buttonMargin` values and the position of the button. This meticulous approach results in a visually appealing and symmetrical button layout:

**After:**
```
16 -- First Tab -- 8 - 8 -- Second Tab -- 8 - 8 -- Last Tab -- 16
```
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-10-14 at 11 33 56](https://github.com/afonsocraposo/buttons_tabbar/assets/43450710/fedbf4a3-ba3b-4c7d-82ed-eee4fc871998)


By applying these changes, the spacing between buttons is now not only consistent but also proportionate, creating a more polished and aesthetically pleasing user interface. This enhancement significantly improves the overall user experience and aligns the application's visual elements with modern design standards.