### PR TITLE
closes #46 - Enable dynamic TabBarView through onSwipe callback

### DIFF
--- a/lib/buttons_tabbar.dart
+++ b/lib/buttons_tabbar.dart
@@ -28,6 +28,8 @@ class ButtonsTabBar extends StatefulWidget implements PreferredSizeWidget {
     this.height = _kTabHeight,
     this.center = false,
     this.onTap,
+    this.onSwipe,
+
   }) : super(key: key) {
     assert(backgroundColor == null || decoration == null);
     assert(unselectedBackgroundColor == null || unselectedDecoration == null);
@@ -147,6 +149,7 @@ class ButtonsTabBar extends StatefulWidget implements PreferredSizeWidget {
   /// callbacks should not make changes to the [TabController] since that would
   /// interfere with the default tap handler.
   final void Function(int)? onTap;
+  final void Function(int)? onSwipe;
 
   @override
   Size get preferredSize {
@@ -476,6 +479,7 @@ class _ButtonsTabBarState extends State<ButtonsTabBar>
     setState(() {
       _prevIndex = _currentIndex;
       _currentIndex = index;
+      widget.onSwipe?.call(index);
     });
     _scrollTo(index); // scroll TabBar if needed
     _triggerAnimation();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.8
+version: 1.3.9
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 


### PR DESCRIPTION
users can use "onSwipe" instead of "onTap" and it will get called whenever the index is changed, whether by tap or by swipe, its more of a bugfix really as this is the expected behavior. 
we can also add the onTap callback instead, but I preferred addition to editing in case I missed sth