### PR TITLE
fix: set default tab width as null

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,4 +35,4 @@ jobs:
         uses: afonsocraposo/actions-flutter-pub-publisher@v1.1.0
         with:
           skip_test: true
-          dry-run: true
+          dry_run: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,5 +34,6 @@ jobs:
       - name: Publish dry run
         uses: afonsocraposo/actions-flutter-pub-publisher@v1.1.0
         with:
+          credential: ${{ secrets.CREDENTIAL_JSON }}
           skip_test: true
           dry_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## [1.3.11] - 10 May 2024
+## [1.3.12] - 22 June 2024
+
+- fix: set default tab width as `null` so it fits its content
+
+## [1.3.11] - 20 June 2024
 
 - Change MaterialStateProperty to WidgetStateProperty . (Compatibility with the last version of flutter )
 - Add the ability to change width attribute for change the tab width .

--- a/lib/buttons_tabbar.dart
+++ b/lib/buttons_tabbar.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 // Default values from the Flutter's TabBar.
 const double _kTabHeight = 46.0;
-const double _kTabWidth = 120.0;
 
 class ButtonsTabBar extends StatefulWidget implements PreferredSizeWidget {
   ButtonsTabBar({
@@ -27,7 +26,7 @@ class ButtonsTabBar extends StatefulWidget implements PreferredSizeWidget {
     this.radius = 7.0,
     this.elevation = 0,
     this.height = _kTabHeight,
-    this.width = _kTabWidth,
+    this.width = null,
     this.center = false,
     this.contentCenter = false,
     this.onTap,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.11
+version: 1.3.12
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 


### PR DESCRIPTION
With this PR we restore the "default" behavior of this package with tab buttons fitting their content.