### PR TITLE
chore: set flutter min sdk 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.3.13] - 22 June 2024
+
+- chore: set Flutter `3.22.0` as minimum sdk version
+
 ## [1.3.12] - 22 June 2024
 
 - fix: set default tab width as `null` so it fits its content

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use Buttons TabBar in your Flutter project, follow these steps:
 dependencies:
   flutter:
     sdk: flutter
-  buttons_tabbar: ^1.3.10
+  buttons_tabbar: ^1.3.13
 ```
 
 2. Run `flutter pub get` to install the package.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,4 +186,4 @@ packages:
     version: "14.2.1"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.12
+version: 1.3.13
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Since this package is now using `WidgetStateProperty`, the minimum supported Flutter SDK is version `3.22.0`.