### PR TITLE
fix: animate to off screen index on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.3.15] - 13 November 2024
+
+- fix: animate to off screen index on init #68
+
 ## [1.3.14] - 13 November 2024
 
 - fix: `animationController` was still active after `buttons_tabbar` was disposed

--- a/lib/buttons_tabbar.dart
+++ b/lib/buttons_tabbar.dart
@@ -228,6 +228,9 @@ class _ButtonsTabBarState extends State<ButtonsTabBar>
     _controller?.animation!.addListener(_handleTabAnimation);
     _controller?.addListener(_handleController);
     _currentIndex = _controller!.index;
+    Future.delayed(Duration.zero, () {
+        _scrollTo(_currentIndex);
+    });
   }
 
   // If the TabBar is rebuilt with a new tab controller, the caller should

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttons_tabbar
 description: A Flutter package that implements a TabBar where each label is a toggle button.
-version: 1.3.14
+version: 1.3.15
 homepage: https://afonsoraposo.com
 repository: https://github.com/Afonsocraposo/buttons_tabbar
 


### PR DESCRIPTION
It was raised on issue #68 that the `ButtonsTabbar` was not animating to the selected index on init. To solve this, I added a call to `_scrollTo` when we attach the controller to the `ButtonsTabbar`, which solves this issue:

In this video I'm restarting the app and it animates to the index 4 on init:

https://github.com/user-attachments/assets/d9057063-ff5b-462f-b4b0-c26e9674131e


